### PR TITLE
fix: pop autoRefreshInterval from status_page info when updating a status page

### DIFF
--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -2132,6 +2132,7 @@ class UptimeKumaApi(object):
         status_page = self.get_status_page(slug)
         status_page.pop("incident")
         status_page.pop("maintenanceList")
+        status_page.pop("autoRefreshInterval")
         status_page.update(kwargs)
         data = self._build_status_page_data(**status_page)
         r = self._call('saveStatusPage', data)


### PR DESCRIPTION
The current version of the library shows this error when using the `save_status_page` method:

`TypeError: UptimeKumaApi._build_status_page_data() got an unexpected keyword argument 'autoRefreshInterval'`

This error appears without specifying any parameters with this name. Debugging the code, I saw that in `api.py:2157`, when retrieving the current data of the status page, the data contains the `autoRefreshInterval` parameter, although `_build_status_page_data` does not expect it, thus creating the situation for this error to appear.

By `pop`ping this parameter from the status page data, the update of the status page works again.