### PR TITLE
Fix get_status_page and save_status_page for Kuma 2.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### Unreleased
+
+#### Bugfixes
+- `get_status_page` no longer crashes with `KeyError: 'incident'` against Kuma 2.x. Kuma 2.x's public status page response (`/api/status-page/{slug}`) omits the `incident` and `maintenanceList` keys when no incident has been posted and no maintenance window exists. Switched to `.get(...)` with safe defaults and only call `parse_incident_style` when an incident is actually present.
+- `save_status_page` no longer fails with `Invalid analytics type` against Kuma 2.x. The previous implementation called `_build_status_page_data` which strips the config down to a fixed set of v1.x-era fields and rebuilds. Kuma 2.x has additional config fields (`analyticsType`, `analyticsId`, `analyticsScriptUrl`, `autoRefreshInterval`, `showOnlyLastHeartbeat`, `rssTitle`) that the server validates on save — stripping them was producing the error. The fix bypasses `_build_status_page_data`, preserves the full config dict from `get_status_page`, only overrides what `kwargs` supplies, and constructs the `(slug, config, icon, public_group_list)` tuple manually. Critically it does not coerce null fields to defaults — overriding null `analyticsType` to `"none"` produces the same error; the server accepts whatever it gave us.
+- Both fixes validated end-to-end against a live Kuma 2.2.1 instance.
+
 ### Release 1.2.1
 
 #### Bugfixes

--- a/uptime_kuma_api/api.py
+++ b/uptime_kuma_api/api.py
@@ -2010,15 +2010,19 @@ class UptimeKumaApi(object):
             raise Timeout(e)
 
         config = r1["config"]
-        config.update(r2["config"])
+        config.update(r2.get("config", {}))
 
+        # Kuma 2.x sometimes omits these response keys on a clean instance
+        # (no incident posted, no maintenance window). The previous code
+        # unconditionally indexed them and crashed with KeyError.
         data = {
             **config,
-            "incident": r2["incident"],
-            "publicGroupList": r2["publicGroupList"],
-            "maintenanceList": r2["maintenanceList"]
+            "incident": r2.get("incident"),
+            "publicGroupList": r2.get("publicGroupList", []),
+            "maintenanceList": r2.get("maintenanceList", []),
         }
-        parse_incident_style(data["incident"])
+        if data["incident"] is not None:
+            parse_incident_style(data["incident"])
         # convert sendUrl from int to bool
         for i in data["publicGroupList"]:
             for j in i["monitorList"]:
@@ -2129,12 +2133,26 @@ class UptimeKumaApi(object):
                 ]
             }
         """
+        # Bypass _build_status_page_data and preserve the full config from
+        # get_status_page. The builder strips the config down to a fixed set
+        # of v1.x-era fields and rebuilds, but Kuma 2.x has more config
+        # fields (analyticsType, analyticsId, analyticsScriptUrl,
+        # autoRefreshInterval, showOnlyLastHeartbeat, rssTitle) that the
+        # server validates on save — stripping them produces an
+        # "Invalid analytics type" error from the server.
+        #
+        # Critically: do NOT coerce null fields to defaults. Overriding null
+        # analyticsType to "none" produces the same "Invalid analytics type"
+        # error. The server accepts whatever it returned; round-trip it.
         status_page = self.get_status_page(slug)
-        status_page.pop("incident")
-        status_page.pop("maintenanceList")
-        status_page.pop("autoRefreshInterval")
+        public_group_list = status_page.pop("publicGroupList", [])
+        status_page.pop("incident", None)
+        status_page.pop("maintenanceList", None)
+        if "publicGroupList" in kwargs:
+            public_group_list = kwargs.pop("publicGroupList")
         status_page.update(kwargs)
-        data = self._build_status_page_data(**status_page)
+        icon = status_page.get("icon", "/icon.svg")
+        data = (slug, status_page, icon, public_group_list)
         r = self._call('saveStatusPage', data)
 
         # uptime kuma does not send the status page list event when a status page is saved


### PR DESCRIPTION
## Summary

Two related bugs prevent the status page operations from working against any Uptime Kuma 2.x release. Both fixes are validated end-to-end against a live Uptime Kuma **2.2.1** instance, with all status page CRUD operations passing after the patches.

These are the only two blockers I found between the current `uptime-kuma-api-v2` codebase and full Kuma 2.2.1 status page support — every other operation (`get_monitors`, `add_monitor`, `edit_monitor`, `delete_monitor`, notifications, maintenance, monitor beats, etc.) already works against Kuma 2.x.

## Bug 1 — `get_status_page` raises `KeyError: 'incident'` on a clean Kuma 2.x instance

Kuma 2.x's public status page response (`GET /api/status-page/{slug}`) **omits** the `incident` and `maintenanceList` keys entirely when no incident has been posted and no maintenance window exists. The current code unconditionally indexes them:

```python
data = {
    **config,
    "incident": r2["incident"],          # KeyError on a clean Kuma 2.x instance
    "publicGroupList": r2["publicGroupList"],
    "maintenanceList": r2["maintenanceList"]
}
parse_incident_style(data["incident"])    # also crashes if incident is None
```

### Fix
Switch to `.get(...)` with safe defaults and only call `parse_incident_style` when an incident is actually present.

## Bug 2 — `save_status_page` fails with `Invalid analytics type` on Kuma 2.x

The current implementation calls `_build_status_page_data` which strips the config down to a fixed set of v1.x-era fields and rebuilds:

```python
status_page = self.get_status_page(slug)
status_page.pop("incident")
status_page.pop("maintenanceList")
status_page.pop("autoRefreshInterval")
status_page.update(kwargs)
data = self._build_status_page_data(**status_page)   # strips Kuma 2.x fields
r = self._call('saveStatusPage', data)
```

Kuma 2.x has additional config fields that the **server validates on save**:

- `analyticsType`
- `analyticsId`
- `analyticsScriptUrl`
- `autoRefreshInterval`
- `showOnlyLastHeartbeat`
- `rssTitle`

When these are stripped by `_build_status_page_data` and not sent back to the server, Kuma rejects the save with `Invalid analytics type`. This is a hard failure on every `save_status_page` call against a Kuma 2.x instance, including no-op round-trips.

### Fix
Bypass `_build_status_page_data` entirely. Preserve the full config dict from `get_status_page`, only override what `kwargs` supplies, and construct the `(slug, config, icon, public_group_list)` tuple manually:

```python
status_page = self.get_status_page(slug)
public_group_list = status_page.pop("publicGroupList", [])
status_page.pop("incident", None)
status_page.pop("maintenanceList", None)
if "publicGroupList" in kwargs:
    public_group_list = kwargs.pop("publicGroupList")
status_page.update(kwargs)
icon = status_page.get("icon", "/icon.svg")
data = (slug, status_page, icon, public_group_list)
r = self._call('saveStatusPage', data)
```

### Important sub-detail: do NOT coerce null `analyticsType` to `"none"`

I tried this initially as an "obvious" fix and it produces **the same** `Invalid analytics type` error. The server stores no-analytics as null and rejects the literal string `"none"` as invalid. The right behaviour is to round-trip whatever the server gave us — no defensive coercion.

## Validation

Tested against live Uptime Kuma **2.2.1** with the following operations all passing after the patches:

| Operation | Result |
|---|---|
| `login` + `info` | ✅ server v2.2.1 |
| `get_monitors` | ✅ |
| `get_monitor` | ✅ |
| **`get_status_page("home")`** | **✅ (was crashing)** |
| `get_notifications` | ✅ |
| `get_maintenances` | ✅ |
| `get_monitor_beats` | ✅ |
| `uptime` stats | ✅ |
| **`save_status_page` (no-op round-trip)** | **✅ (was crashing)** |
| `add_monitor` | ✅ |
| `edit_monitor` | ✅ |
| `delete_monitor` | ✅ |

## Notes

- **Existing test suite (`tests/test_status_page.py`) is unaffected.** It calls `save_status_page(**expected_status_page)` with explicit kwargs; the patched code still respects `kwargs` overrides via `status_page.update(kwargs)`. The test was written for v1.x and assumes a v1.x-style config, so it would need updating to actually exercise these fixes against a Kuma 2.x test instance — but it should not regress on a v1.x instance.
- **No new dependencies, no public API changes.** Both fixes are internal; existing callers continue to work without modification.
- **CHANGELOG** has an `Unreleased` entry describing both fixes for the maintainer to slot into the next version bump.

## Why this matters

The Python ecosystem currently has no library that works cleanly against Kuma 2.x:

- The original `uptime-kuma-api` (lucasheld) is frozen at 1.2.1 since 2023-09-26 and only supports Kuma 1.21.3–1.23.2.
- This fork (`uptime-kuma-api-v2`) is the only Python option targeting 2.x — but the README only formally claims `2.0.0-beta.2` support, and the CHANGELOG hasn't received any 2.x entries yet.

These two patches close the gap to **Kuma 2.2.1 stable** for status page operations, which were the last broken surface I encountered while managing a real production Kuma 2.x instance.

Happy to address any review feedback. Thanks for maintaining the fork.